### PR TITLE
added shapeType field to Panel class

### DIFF
--- a/src/io/github/rowak/nanoleafapi/Aurora.java
+++ b/src/io/github/rowak/nanoleafapi/Aurora.java
@@ -1046,7 +1046,8 @@ public class Aurora
 				int x = data.getInt("x");
 				int y = data.getInt("y");
 				int o = data.getInt("o");
-				pd[i] = new Panel(panelId, x, y, o);
+				int shapeType = data.getInt("shapeType");
+				pd[i] = new Panel(panelId, x, y, o, shapeType);
 			}
 			return pd;
 		}

--- a/src/io/github/rowak/nanoleafapi/Panel.java
+++ b/src/io/github/rowak/nanoleafapi/Panel.java
@@ -12,6 +12,7 @@ import io.github.rowak.nanoleafapi.StatusCodeException.UnauthorizedException;
 public class Panel extends Position
 {
 	private int id, r, g, b, w;
+	private int shapeType;
 	
 	/**
 	 * Creates a new instance of a <code>Panel</code>.
@@ -26,6 +27,20 @@ public class Panel extends Position
 		this.id = id;
 	}
 	
+	/**
+	 * Creates a new instance of a <code>Panel</code>.
+	 * @param id  the id of the panel
+	 * @param x  the x-value of the panel location
+	 * @param y  the y-value of the panel location
+	 * @param orientation  the panel's orientation on the Aurora grid
+	 * @param shapeType  the panel's shape type
+	 */
+	public Panel(int id, int x, int y, int orientation, int shapeType)
+	{
+		this(id, x, y, orientation);
+		this.shapeType = shapeType;
+	}
+
 	/**
 	 * Gets the unique ID for the panel.
 	 * @return  the panel's unique ID
@@ -42,6 +57,15 @@ public class Panel extends Position
 	public Color getColor()
 	{
 		return Color.fromRGB(r, g, b);
+	}
+
+	/**
+	 * Gets the panel's shape type
+	 * @return  the panel's shape type
+	 */
+	public int getShapeType()
+	{
+		return this.shapeType;
 	}
 	
 	/**


### PR DESCRIPTION
I needed the `shapeType` field in the panel data from the `/panelLayout/layout` endpoint response for a project I was doing.

This adds the field to the `Panel` class, and a getter method and new constructor.

Also updates the `Aurora.getPanels()` method to map the `shapeType` field from the API response into the `Panel` objects.